### PR TITLE
fix: Lock docker base image (closes #32)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-slim
+FROM node:12.11.1-slim
 
 RUN apt-get update && \
     apt-get install -y git calibre
@@ -15,4 +15,3 @@ RUN git clone -b fix/filename-regex https://github.com/PauloASilva/gitbook.git ~
     gitbook alias ~/gitbook-custom latest
 
 WORKDIR /build
-


### PR DESCRIPTION
Lock docker image to node:12.11.1-slim to avoid issues with
deprecated gitbook-cli and gitbook versions.